### PR TITLE
Add checks for future's state before setting result

### DIFF
--- a/asyncqt/_windows.py
+++ b/asyncqt/_windows.py
@@ -44,7 +44,8 @@ class _ProactorEventLoop(asyncio.ProactorEventLoop):
             except OSError:
                 self._logger.warning('Event callback failed', exc_info=sys.exc_info())
             else:
-                f.set_result(value)
+                if not f.cancelled():
+                    f.set_result(value)
 
     def _before_run_forever(self):
         self.__event_poller.start(self._proactor)


### PR DESCRIPTION
_Merging into my fork of 'asyncqt' so that it can be transferred to [qasync](https://github.com/CabbageDevelopment/qasync)._

`set_result` can throw an `InvalidStateError` if the future is done or cancelled, so this adds a check. (https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.set_result)